### PR TITLE
Handle JSON and add tests

### DIFF
--- a/lib/geocodio.js
+++ b/lib/geocodio.js
@@ -30,10 +30,32 @@ var Geocodio = module.exports = function (config) {
     request(options, function (err, res, body) {
       if (err) {
         cb(err)
-      } else if (res.statusCode !== 200) {
-        cb(new Error(body.error), body, res)
       } else {
-        cb(null, body, res)
+        var errMsg = null
+        var ret = {
+          err: null
+        }
+
+        try {
+          ret.body = JSON.parse(body)
+        } catch (e) {
+          ret.body = body
+          errMsg = 'Invalid JSON'
+        }
+
+        if (res.statusCode !== 200) {
+          if (typeof ret.body === 'object') {
+            errMsg = ret.body.error
+          } else {
+            errMsg = ret.body
+          }
+        }
+
+        if (errMsg) {
+          ret.err = new Error(errMsg)
+        }
+
+        cb(ret.err, ret.body, res)
       }
     })
 

--- a/test/test.js
+++ b/test/test.js
@@ -4,13 +4,13 @@ var Geocodio = require('..')
 var assert = require('assert')
 
 describe('Geocodio', function () {
-  it('Is instantiable', function () {
+  it('is instantiable', function () {
     var client = new Geocodio()
 
     assert(client instanceof Geocodio)
   })
 
-  it('Is configurable', function () {
+  it('is configurable', function () {
     var config = {
       base_endpoint: 'http://api.geocod.io/v2',
       foo: 'bar'
@@ -30,10 +30,82 @@ describe('Geocodio', function () {
     assert.equal(client.config.foo, config.foo)
   })
 
-  it('Has prototype methods', function () {
+  it('has prototype methods', function () {
     var client = new Geocodio()
 
     assert(typeof client.get === 'function')
     assert(typeof client.post === 'function')
+  })
+
+  it('throws an exception with a invalid host', function (done) {
+    var config = {
+      base_endpoint: 'http://example.invalid'
+    }
+
+    var client = new Geocodio(config)
+
+    client.get('geocode', {}, function (err, response) {
+      assert.throws(
+        function () {
+          if (err) throw err
+        },
+        /ENOTFOUND/
+      )
+      done()
+    })
+  })
+
+  it('throws an exception with an invalid API key', function (done) {
+    var config = {
+      base_endpoint: 'http://api.geocod.io/v1'
+    }
+
+    var client = new Geocodio(config)
+
+    client.get('geocode', {}, function (err, response) {
+      assert.throws(
+        function () {
+          if (err) throw err
+        },
+        /Invalid API key/
+      )
+      done()
+    })
+  })
+
+  it('throws an exception with an invalid endpoint', function (done) {
+    var config = {
+      base_endpoint: 'http://api.geocod.io/invalid'
+    }
+
+    var client = new Geocodio(config)
+
+    client.get('geocode', {}, function (err, response) {
+      assert.throws(
+        function () {
+          if (err) throw err
+        },
+        /Invalid endpoint/
+      )
+      done()
+    })
+  })
+
+  it('throws an exception with an invalid non-JSON endpoint', function (done) {
+    var config = {
+      base_endpoint: 'http://geocod.io/#invalid'
+    }
+
+    var client = new Geocodio(config)
+
+    client.get('geocode', {}, function (err, response) {
+      assert.throws(
+        function () {
+          if (err) throw err
+        },
+        /Invalid JSON/
+      )
+      done()
+    })
   })
 })


### PR DESCRIPTION
This commit adds tests for invalid hosts, invalid API keys, invalid endpoints, HTTP 200 responses without valid JSON, and automatically returns the response as a JavaScript object instead of a string that needs to be parsed.

This is a **breaking change** and is backward-incompatible with any application that expects a string.
### Before

``` javascript
geocodio.get('geocode', {q: addr}, function(err, response){
  if (err) throw err;

  try {
    console.log(JSON.parse(response).results);
  } catch (e) {
    throw new Error("Invalid JSON: " + response);
  }
});
```
### After

``` javascript
geocodio.get('geocode', {q: addr}, function(err, response){
  if (err) throw err;

  console.log(response.results);
});
```

It would make sense for me for `err` to reflect the validity of the JSON, since if the JSON is invalid something definitely went wrong – I don't think it adds any practical value for the user to have to use `try...catch` blocks to handle the invalid JSON edge-case, but I'm open to opinions. Thanks for your work on this API client @desmondmorris!
