### PR TITLE
Update request dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/desmondmorris/node-geocodio/issues"
   },
   "dependencies": {
-    "request": "~2.33.0"
+    "request": "^2.74.0"
   },
   "devDependencies": {
     "mocha": "^2.2.4",


### PR DESCRIPTION
This updates the request dependency to address an [issue](https://github.com/request/request/issues/455) where node-geocodio breaks when used with browserify.
